### PR TITLE
Fix #15 by forcing dfm_weight and dfm_group

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: quanteda.textmodels
 Type: Package
 Title: Scaling Models and Classifiers for Textual Data
-Version: 0.9.0
+Version: 0.9.1
 Description: Scaling models and classifiers for sparse matrix objects representing textual data in the form of a document-feature matrix. 
     Originally from the 'quanteda' package, these models take document-feature matrix objects as inputs.
 Authors@R: c( 

--- a/R/textmodel_affinity.R
+++ b/R/textmodel_affinity.R
@@ -58,7 +58,7 @@ textmodel_affinity.dfm <- function(x, y, exclude = NULL,
     if (!sum(x)) stop(message_error("dfm_empty"))
 
     # estimate reference distributions
-    counts <- dfm(x[!is.na(y),], groups = y[!is.na(y)], tolower = FALSE)
+    counts <- dfm_group(x, groups = y, force = TRUE)
 
     # determine support set
     support <- colSums(counts) > 0

--- a/R/textmodel_nb.R
+++ b/R/textmodel_nb.R
@@ -121,9 +121,9 @@ textmodel_nb.dfm <- function(x, y, smooth = 1,
 
     ## distribution
     if (distribution == "Bernoulli")
-        temp <- dfm_weight(temp, "boolean")
+        temp <- dfm_weight(temp, "boolean", force = TRUE)
 
-    temp <- dfm_group(temp, class)
+    temp <- dfm_group(temp, class, force = TRUE)
 
     freq <- rowSums(as.matrix(table(class)))
     if (prior == "uniform") {
@@ -138,7 +138,7 @@ textmodel_nb.dfm <- function(x, y, smooth = 1,
     }
 
     if (distribution == "multinomial") {
-        PwGc <- dfm_weight(dfm_smooth(temp, smooth), scheme = "prop")
+        PwGc <- dfm_weight(dfm_smooth(temp, smooth), scheme = "prop", force = TRUE)
     } else if (distribution == "Bernoulli") {
         # denominator here is same as IIR Fig 13.3 line 8 - see also Eq. 13.7
         PwGc <- (temp + smooth) / (freq + smooth * ndoc(temp))

--- a/man/textmodels.Rd
+++ b/man/textmodels.Rd
@@ -6,10 +6,10 @@
 \alias{_PACKAGE}
 \alias{quanteda.textmodels}
 \alias{quanteda.textmodels-package}
-\title{quanteda.textmodels: Scaling models and classifiers for textual data}
+\title{quanteda.textmodels: Scaling Models and Classifiers for Textual Data}
 \description{
-Scaling models and classifers for sparse matrix objects representing textual data in the form of a document-feature matrix. 
-    Originally from the quanteda package, these models take quanteda dfm (document-feature matrix) objects as inputs.
+Scaling models and classifiers for sparse matrix objects representing textual data in the form of a document-feature matrix. 
+    Originally from the 'quanteda' package, these models take document-feature matrix objects as inputs.
 }
 \seealso{
 Useful links:

--- a/man/textplot_scale1d.Rd
+++ b/man/textplot_scale1d.Rd
@@ -32,6 +32,7 @@ applies when \code{margin = "documents"}.}
 \item{groups}{either: a character vector containing the names of document
 variables to be used for grouping; or a factor or object that can be
 coerced into a factor equal in length or rows to the number of documents.
+\code{NA} values of the grouping value are dropped.
 See \link[quanteda]{groups} for details.}
 
 \item{highlighted}{a vector of feature names to draw attention to in a

--- a/tests/testthat/test-textmodel_affinity.R
+++ b/tests/testthat/test-textmodel_affinity.R
@@ -1,10 +1,12 @@
 context("tests of textmodel_affinity")
 
 test_that("textmodel_affinity works as expected",  {
-    fitted <- textmodel_affinity(data_dfm_lbgexample, y = c("L", NA, NA, NA, "R", NA))
+    fitted <- textmodel_affinity(data_dfm_lbgexample,
+                                 y = c("L", NA, NA, NA, "R", NA))
     predicted <- predict(fitted)
     expect_gte(coef(predicted)["V1", "L"], 0.95)
-    expect_equal(rownames(coef(predicted)), c("R1","R2","R3","R4","R5","V1"))
+    expect_equal(rownames(coef(predicted)),
+                 c("R1", "R2", "R3", "R4", "R5", "V1"))
 })
 
 test_that("textmodel_affinity works for tolower = TRUE dfm objects (#1338)", {
@@ -23,7 +25,7 @@ test_that("textmodel_affinity works for tolower = TRUE dfm objects (#1338)", {
 })
 
 test_that("raises error when dfm is empty (#1419)",  {
-    
+
     mx <- dfm_trim(data_dfm_lbgexample, 1000)
     expect_error(textmodel_affinity(mx, y = c(-1, NA, NA, NA, 1, NA)),
                  quanteda:::message_error("dfm_empty"))

--- a/tests/testthat/test-textmodel_ca.R
+++ b/tests/testthat/test-textmodel_ca.R
@@ -1,4 +1,4 @@
-context('Testing textmodel-ca.R')
+context("Testing textmodel-ca.R")
 
 ie2010dfm <- dfm(data_corpus_irishbudget2010)
 
@@ -6,59 +6,59 @@ test_that("textmodel-ca (rsvd) works as expected as ca::ca", {
     skip_if_not_installed("ca")
     wca <- ca::ca(as.matrix(ie2010dfm))
     wtca <- textmodel_ca(ie2010dfm)
-    expect_equal(wca$rowdist, wtca$rowdist, tolerance = 1e-6)
-    expect_equal(wca$coldist, wtca$coldist, tolerance = 1e-6)
-    
-    expect_equal(abs(wca$rowcoord[,1]), abs(wtca$rowcoord[,1]), tolerance = 1e-6)
-    expect_equal(abs(wca$colcoord[,1]), abs(wtca$colcoord[,1]), tolerance = 1e-6)
-    
-    expect_equal(abs(wca$rowcoord[,2]), abs(wtca$rowcoord[,2]), tolerance = 1e-6)
-    expect_equal(abs(wca$colcoord[,2]), abs(wtca$colcoord[,2]), tolerance = 1e-6)
-    
-    expect_equal(wca$rowinertia, wtca$rowinertia, tolerance = 1e-6)
-    expect_equal(wca$colinertia, wtca$colinertia, tolerance = 1e-6)
-    
-    expect_equal(wca$sv[seq_along(wtca$sv)], wtca$sv, tolerance = 1e-6)
+    expect_equal(wca$rowdist, wtca$rowdist, tol = 1e-6)
+    expect_equal(wca$coldist, wtca$coldist, tol = 1e-6)
+
+    expect_equal(abs(wca$rowcoord[, 1]), abs(wtca$rowcoord[, 1]), tol = 1e-6)
+    expect_equal(abs(wca$colcoord[, 1]), abs(wtca$colcoord[, 1]), tol = 1e-6)
+
+    expect_equal(abs(wca$rowcoord[, 2]), abs(wtca$rowcoord[, 2]), tol = 1e-6)
+    expect_equal(abs(wca$colcoord[, 2]), abs(wtca$colcoord[, 2]), tol = 1e-6)
+
+    expect_equal(wca$rowinertia, wtca$rowinertia, tol = 1e-6)
+    expect_equal(wca$colinertia, wtca$colinertia, tol = 1e-6)
+
+    expect_equal(wca$sv[seq_along(wtca$sv)], wtca$sv, tol = 1e-6)
 })
 
 test_that("textmodel-ca works as expected as ca::ca : use mt", {
     skip_if_not_installed("ca")
     wca <- ca::ca(as.matrix(ie2010dfm))
     wtca <- textmodel_ca(ie2010dfm, sparse = TRUE)
-    
+
     expect_gt(cor(wca$rowdist, wtca$rowdist), 0.99)
     expect_gt(cor(wca$coldist, wtca$coldist), 0.99)
-    
-    expect_gt(cor(abs(wca$rowcoord[,1]), abs(wtca$rowcoord[,1])), 0.99)
-    expect_gt(cor(abs(wca$colcoord[,1]), abs(wtca$colcoord[,1])), 0.99)
-    
-    expect_gt(cor(abs(wca$rowcoord[,2]), abs(wtca$rowcoord[,2])), 0.99)
-    expect_gt(cor(abs(wca$colcoord[,2]), abs(wtca$colcoord[,2])), 0.99)
-    
+
+    expect_gt(cor(abs(wca$rowcoord[, 1]), abs(wtca$rowcoord[, 1])), 0.99)
+    expect_gt(cor(abs(wca$colcoord[, 1]), abs(wtca$colcoord[, 1])), 0.99)
+
+    expect_gt(cor(abs(wca$rowcoord[, 2]), abs(wtca$rowcoord[, 2])), 0.99)
+    expect_gt(cor(abs(wca$colcoord[, 2]), abs(wtca$colcoord[, 2])), 0.99)
+
     expect_gt(cor(wca$rowinertia, wtca$rowinertia), 0.99)
     expect_gt(cor(wca$colinertia, wtca$colinertia), 0.99)
-    
+
     cc <- cor(wca$sv[seq_along(wtca$sv)], wtca$sv)
     expect_gt(cc, 0.99)
 })
 
-test_that("textmodel-ca works as expected as ca::ca: for given number of dimension", {
+test_that("textmodel_ca matches ca::ca() for given number of dimension", {
     skip_if_not_installed("ca")
     wca <- ca::ca(as.matrix(ie2010dfm))
     wtca <- textmodel_ca(ie2010dfm, nd = 10)
-    expect_equal(wca$rowdist, wtca$rowdist, tolerance = 1e-6)
-    expect_equal(wca$coldist, wtca$coldist, tolerance = 1e-6)
-    
-    expect_equal(abs(wca$rowcoord[,1]), abs(wtca$rowcoord[,1]), tolerance = 1e-6)
-    expect_equal(abs(wca$colcoord[,1]), abs(wtca$colcoord[,1]), tolerance = 1e-6)
-    
-    expect_equal(abs(wca$rowcoord[,2]), abs(wtca$rowcoord[,2]), tolerance = 1e-6)
-    expect_equal(abs(wca$colcoord[,2]), abs(wtca$colcoord[,2]), tolerance = 1e-6)
-    
-    expect_equal(wca$rowinertia, wtca$rowinertia, tolerance = 1e-6)
-    expect_equal(wca$colinertia, wtca$colinertia, tolerance = 1e-6)
-    
-    expect_equal(wca$sv[seq_along(wtca$sv)], wtca$sv, tolerance = 1e-6)
+    expect_equal(wca$rowdist, wtca$rowdist, tol = 1e-6)
+    expect_equal(wca$coldist, wtca$coldist, tol = 1e-6)
+
+    expect_equal(abs(wca$rowcoord[, 1]), abs(wtca$rowcoord[, 1]), tol = 1e-6)
+    expect_equal(abs(wca$colcoord[, 1]), abs(wtca$colcoord[, 1]), tol = 1e-6)
+
+    expect_equal(abs(wca$rowcoord[, 2]), abs(wtca$rowcoord[, 2]), tol = 1e-6)
+    expect_equal(abs(wca$colcoord[, 2]), abs(wtca$colcoord[, 2]), tol = 1e-6)
+
+    expect_equal(wca$rowinertia, wtca$rowinertia, tol = 1e-6)
+    expect_equal(wca$colinertia, wtca$colinertia, tol = 1e-6)
+
+    expect_equal(wca$sv[seq_along(wtca$sv)], wtca$sv, tol = 1e-6)
 })
 
 test_that("textmodel-ca(sparse) works as expected on another dataset", {
@@ -66,19 +66,19 @@ test_that("textmodel-ca(sparse) works as expected on another dataset", {
     skip_if_not_installed("ca")
     wca <- ca::ca(as.matrix(usdfm))
     wtca <- textmodel_ca(usdfm, sparse = TRUE)
-    
+
     expect_gt(cor(wca$rowdist, wtca$rowdist), 0.99)
     expect_gt(cor(wca$coldist, wtca$coldist), 0.99)
-    
-    expect_gt(cor(abs(wca$rowcoord[,1]), abs(wtca$rowcoord[,1])), 0.99)
-    expect_gt(cor(abs(wca$colcoord[,1]), abs(wtca$colcoord[,1])), 0.99)
-    
-    expect_gt(cor(abs(wca$rowcoord[,2]), abs(wtca$rowcoord[,2])), 0.99)
-    expect_gt(cor(abs(wca$colcoord[,2]), abs(wtca$colcoord[,2])), 0.99)
-    
+
+    expect_gt(cor(abs(wca$rowcoord[, 1]), abs(wtca$rowcoord[, 1])), 0.99)
+    expect_gt(cor(abs(wca$colcoord[, 1]), abs(wtca$colcoord[, 1])), 0.99)
+
+    expect_gt(cor(abs(wca$rowcoord[, 2]), abs(wtca$rowcoord[, 2])), 0.99)
+    expect_gt(cor(abs(wca$colcoord[, 2]), abs(wtca$colcoord[, 2])), 0.99)
+
     expect_gt(cor(wca$rowinertia, wtca$rowinertia), 0.99)
     expect_gt(cor(wca$colinertia, wtca$colinertia), 0.99)
-    
+
     cc <- cor(wca$sv[seq_along(wtca$sv)], wtca$sv)
     expect_gt(cc, 0.99)
 })
@@ -103,9 +103,9 @@ test_that("ca textplot_scale1d method works", {
 })
 
 test_that("raises error when dfm is empty (#1419)",  {
-    
+
     mx <- dfm_trim(data_dfm_lbgexample, 1000)
     expect_error(textmodel_ca(mx),
                  quanteda:::message_error("dfm_empty"))
-    
+
 })

--- a/tests/testthat/test-textmodel_nb.R
+++ b/tests/testthat/test-textmodel_nb.R
@@ -10,13 +10,17 @@ nb_dfm <- dfm(txt, tolower = FALSE)
 nb_class <- factor(c("Y", "Y", "Y", "N", NA), ordered = TRUE)
 
 nb_multi_smooth <-
-    textmodel_nb(nb_dfm, nb_class, prior = "docfreq", distribution = "multinomial", smooth = 1)
+    textmodel_nb(nb_dfm, nb_class, prior = "docfreq",
+                 distribution = "multinomial", smooth = 1)
 nb_multi_nosmooth <-
-    textmodel_nb(nb_dfm, nb_class, prior = "docfreq", distribution = "multinomial", smooth = 0)
+    textmodel_nb(nb_dfm, nb_class, prior = "docfreq",
+                 distribution = "multinomial", smooth = 0)
 nb_bern_smooth <-
-    textmodel_nb(nb_dfm, nb_class, prior = "docfreq", distribution = "Bernoulli", smooth = 1)
+    textmodel_nb(nb_dfm, nb_class, prior = "docfreq",
+                 distribution = "Bernoulli", smooth = 1)
 nb_bern_nosmooth <-
-    textmodel_nb(nb_dfm, nb_class, prior = "docfreq", distribution = "Bernoulli", smooth = 0)
+    textmodel_nb(nb_dfm, nb_class, prior = "docfreq",
+                 distribution = "Bernoulli", smooth = 0)
 
 test_that("class priors are preserved in correct order", {
     expect_equal(textmodel_nb(nb_dfm, nb_class, prior = "uniform")$Pc,
@@ -183,5 +187,15 @@ test_that("constant predictor raises exception", {
     expect_error(
         textmodel_nb(x, y = factor(c("Y", "Y", "Y", "Y", NA), levels = c("Y", "N"))),
         "y cannot be constant"
+    )
+})
+
+test_that("textmodel_nb() works with weighted dfm", {
+    dfmat <- dfm_tfidf(data_dfm_lbgexample)
+    expect_silent(
+        tmod <- textmodel_nb(dfmat, y = c("N", "N", NA, "Y", "Y", NA))
+    )
+    expect_silent(
+        predict(tmod)
     )
 })

--- a/tests/testthat/test-textmodel_svm.R
+++ b/tests/testthat/test-textmodel_svm.R
@@ -156,3 +156,20 @@ test_that("the svmlin model works", {
         "y must contain two values only"
     )
 })
+
+test_that("textmodel_svm/svmlin() work with weighted dfm", {
+    dfmat <- dfm_tfidf(data_dfm_lbgexample)
+    expect_silent(
+        tmod <- textmodel_svm(dfmat, y = c("N", "N", NA, "Y", "Y", NA))
+    )
+    expect_silent(
+        predict(tmod)
+    )
+    expect_silent(
+        tmod <- textmodel_svmlin(dfmat, y = c("N", "N", NA, "Y", "Y", NA))
+    )
+    expect_silent(
+        predict(tmod)
+    )
+})
+

--- a/tests/testthat/test-textmodel_wordfish.R
+++ b/tests/testthat/test-textmodel_wordfish.R
@@ -25,7 +25,7 @@ test_that("textmodel-wordfish works as expected: dense vs sparse vs sparse+mt", 
 test_that("print/show/summary method works as expected", {
     expect_output(
         print(wfm),
-        "^\\nCall:\\ntextmodel_wordfish\\.dfm\\(.*Dispersion.*14 documents; 5140 features\\.$"
+        "^\\nCall:\\ntextmodel_wordfish\\.dfm\\(.*Dispersion.*14 documents; 514\\d features\\.$"
     )
     expect_output(
         print(wfs),
@@ -114,4 +114,3 @@ test_that("raises error when dfm is empty (#1419)",  {
                  quanteda:::message_error("dfm_empty"))
 
 })
-

--- a/tests/testthat/test-textmodel_wordscores.R
+++ b/tests/testthat/test-textmodel_wordscores.R
@@ -281,3 +281,13 @@ test_that("predict.textmodel_wordscores correctly implements smoothing (#1476)",
         predict(ws_smooth1, newdata = dfm_smooth(data_dfm_lbgexample, smoothing = 1))
     )
 })
+
+test_that("textmodel_wordscores() work with weighted dfm", {
+    dfmat <- dfm_tfidf(data_dfm_lbgexample)
+    expect_silent(
+        tmod <- textmodel_wordscores(dfmat, y = c(-1, -1, NA, 1, 1, NA))
+    )
+    expect_silent(
+        predict(tmod)
+    )
+})


### PR DESCRIPTION
When called on their own, `dfm_weight()` and `dfm_group()` will refused to apply more weights or sum counts (respectively) if a dfm has already been weighted, _unless_ the `force = TRUE` argument is specified. Because these calls are inside all of the supervised model functions, and the default is `force = FALSE`, this halted with an error when a user wanted to train a model on a weighted dfm, say one that had been weighted by `dfm_tfidf()`. While it's questionable whether one should weight by tf-idf before fitting a multinomial Naive Bayes classifier, this PR nonetheless forces the weight (or group) and lets the supervised model fitting proceed. _Caveat emptor_.

Solves #15.
